### PR TITLE
fix: async forRoot global prop

### DIFF
--- a/src/email.module.ts
+++ b/src/email.module.ts
@@ -45,7 +45,9 @@ export class EmailModule {
     };
   }
 
-  static forRootAsync(options: EmailModuleAsyncOptions): DynamicModule {
+  static forRootAsync(
+    options: EmailModuleAsyncOptions & Pick<DynamicModule, 'global'>
+  ): DynamicModule {
     return {
       module: EmailModule,
       imports: options.imports,


### PR DESCRIPTION
Not able to register module globally if using async config. Fixed.